### PR TITLE
MediaStreamを流す先をaudioタグのsrcObjectに直接設定、Firefox対策

### DIFF
--- a/js/vtuber.js
+++ b/js/vtuber.js
@@ -72,6 +72,7 @@ var startAnimation = function(){
 }
 
 var setupMicrophone = function(){
+navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 navigator.getUserMedia(
 	{audio : true},
 	function(stream){

--- a/js/vtuber.js
+++ b/js/vtuber.js
@@ -75,7 +75,14 @@ var setupMicrophone = function(){
 navigator.getUserMedia(
 	{audio : true},
 	function(stream){
-		document.querySelector('audio').src = URL.createObjectURL(stream);
+		var audioElem = document.querySelector('audio');
+		if ('srcObject' in audioElem) {
+			// 最近のブラウザ向け
+			audioElem.srcObject = stream;
+		} else {
+			// 昔のブラウザ向け
+			audioElem.src = URL.createObjectURL(stream);
+		}
 		var audioContext = new AudioContext();
 		var analyser = audioContext.createAnalyser();
 		var timeDomain = new Float32Array(analyser.frequencyBinCount);


### PR DESCRIPTION
@spinachmedia 様
突然失礼いたします。当方、[こちらの記事](https://glodia.jp/blog/javascript%E3%81%A7%E3%83%AA%E3%83%83%E3%83%97%E3%82%B7%E3%83%B3%E3%82%AF%E3%82%82%E3%81%A9%E3%81%8D%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%81%A6%E3%81%BF%E3%82%8B)を読んでこちらのリポジトリにたどり着きました。手元で試してみたところ、少し修正が必要であったため修正してみました。そのコードを作者様にも共有したくPRを出します。もしよかったらマージしていただけると嬉しいです。

動作確認に用いた環境を以下に示します。

|item|version|
|---|---|
|OS|Windows 10 Pro 64bit (20H2)|
|Google Chrome|91.0.4472.124|
|Microsoft Edge|91.0.864.71|
|Mozilla Firefox|90.0.1|

## 1点目

実際に手元で試してみたところ、以下のようなエラーが出ました。

```
Uncaught TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.
```

[HTMLMedia​Element​.src​Object - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/HTMLMediaElement/srcObject)によると

> メディアソース仕様の古いバージョンでは、オブジェクト URL を作成するために createObjectURL() を使用してから、その URL を src に設定する必要がありました。 現在は、MediaStream を srcObject に直接設定できます。

とのことでしたので、`audio`タグに`srcObject`属性が付いている場合はそれに直接、`getUserMedia()`から得られたMediaStreamオブジェクトを設定するような変更を加えました。ついていない場合は従来通りです。これで上記のエラーはGoogle Chromeを使用した場合には消えました。

## 2点目

上記の一点目の変更の後、Firefoxで動作するか試したところ`navigator`に`getUserMedia()`が存在せずエラーになっておりました。そこでFirefoxの場合はベンダープレフィックスを付けた`mozGetUserMedia()`を代わりに使うように変更しました。

もっとも、`navigator.getUserMedia()`はdeprecatedらしく、代わりに`navigator.mediaDevices.getUserMedia()`を使うべしとの記載がMDNにありました。

> 新しいコードでは代わりに Navigator.mediaDevices.getUserMedia() (en-US) を使用してください。
> [Navigator.getUserMedia() - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Navigator/getUserMedia) より

ただ新しい方のメソッドはPromiseを返すため書き換える部分が多くなりそうで、今回は使用しませんでした。

以上です。